### PR TITLE
PG-934 Fix old telemetry files loading on startup

### DIFF
--- a/percona_pg_telemetry.c
+++ b/percona_pg_telemetry.c
@@ -272,7 +272,7 @@ load_telemery_files(void)
     }
 
 #if PG_VERSION_NUM >= 130000
-    list_sort(files_list, compareFileNames);
+    list_sort(files_list, compare_file_names);
 #else
     files_list = list_qsort(files_list, compare_file_names);
 #endif

--- a/percona_pg_telemetry.c
+++ b/percona_pg_telemetry.c
@@ -79,9 +79,9 @@ static char *generate_filename(char *filename);
 static bool validate_dir(char *folder_path);
 
 #if PG_VERSION_NUM >= 130000
-static int compareFileNames(const ListCell *a, const ListCell *b);
+static int compare_file_names(const ListCell *a, const ListCell *b);
 #else
-static int compareFileNames(const void *a, const void *b);
+static int compare_file_names(const void *a, const void *b);
 #endif
 
 /* Database information collection and writing to file */
@@ -274,7 +274,7 @@ load_telemery_files(void)
 #if PG_VERSION_NUM >= 130000
     list_sort(files_list, compareFileNames);
 #else
-    files_list = list_qsort(files_list, compareFileNames);
+    files_list = list_qsort(files_list, compare_file_names);
 #endif
 
     foreach(lc, files_list)
@@ -290,7 +290,7 @@ load_telemery_files(void)
 
 #if PG_VERSION_NUM >= 130000
 static int
-compareFileNames(const ListCell *a, const ListCell *b)
+compare_file_names(const ListCell *a, const ListCell *b)
 {
 	char	   *fna = (char *) lfirst(a);
 	char	   *fnb = (char *) lfirst(b);
@@ -299,7 +299,7 @@ compareFileNames(const ListCell *a, const ListCell *b)
 
 #else
 static int
-compareFileNames(const void *a, const void *b)
+compare_file_names(const void *a, const void *b)
 {
 	char	   *fna = (char *) lfirst(*(ListCell **) a);
 	char	   *fnb = (char *) lfirst(*(ListCell **) b);


### PR DESCRIPTION
[PG-934 ](https://perconadev.atlassian.net/browse/PG-934)

There were two problems: 
1) `cleaup_telemetry_dir` was trying to load old telemetry filenames, but instead of full file paths, it loaded only filenames. So it wasn't able to remove actual files from filesystem on cyclic buffer wraparound. 
2) When `cleaup_telemetry_dir` read files from directory it doesn't consider that `ReadDir` may (and will) returns files in non-alphabetical order. So files were loaded in wrong order in cyclic buffer.

P.S. I renamed `cleaup_telemetry_dir` to `load_telemery_files` because its purpose not to cleanup dir, but load old files with respect of the limits.